### PR TITLE
Improve JSON parsing

### DIFF
--- a/src/services/openrouter-service.ts
+++ b/src/services/openrouter-service.ts
@@ -3,6 +3,8 @@ export interface OpenRouterModel {
   name: string
 }
 
+import { safeParseJSON } from '@/utils/utils'
+
 export async function fetchOpenRouterModels(apiKey: string): Promise<OpenRouterModel[]> {
   const res = await fetch('https://openrouter.ai/api/v1/models', {
     headers: {
@@ -14,6 +16,6 @@ export async function fetchOpenRouterModels(apiKey: string): Promise<OpenRouterM
   if (!res.ok) {
     throw new Error(`Failed to fetch models: ${res.status}`)
   }
-  const data = await res.json()
-  return data.data as OpenRouterModel[]
+  const data = await safeParseJSON<{ data: OpenRouterModel[] }>(res)
+  return data.data
 }

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { safeParseJSON } from './utils'
+
+function createResponse(body: string, contentType = 'application/json') {
+  return new Response(body, { headers: { 'Content-Type': contentType } })
+}
+
+describe('safeParseJSON', () => {
+  it('parses valid json', async () => {
+    const res = createResponse('{"a":1}')
+    const data = await safeParseJSON<{a:number}>(res)
+    expect(data.a).toBe(1)
+  })
+
+  it('throws on invalid json', async () => {
+    const res = createResponse('<html></html>', 'text/html')
+    await expect(safeParseJSON(res)).rejects.toThrow(/Invalid JSON/)
+  })
+})

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -40,3 +40,17 @@ export function calculateCost(inputTokens: number, outputTokens: number, model: 
     (outputTokens / 1000000) * modelPricing.output
   )
 }
+
+/**
+ * Safely parse a `Response` body as JSON. If the body cannot be parsed,
+ * an error is thrown that includes the first part of the response text
+ * to aid debugging.
+ */
+export async function safeParseJSON<T = any>(res: Response): Promise<T> {
+  const text = await res.text()
+  try {
+    return JSON.parse(text) as T
+  } catch {
+    throw new Error(`Invalid JSON response: ${text.slice(0, 200)}`)
+  }
+}


### PR DESCRIPTION
## Summary
- add `safeParseJSON` utility for robust response parsing
- use the new helper in AI and OpenRouter services
- test `safeParseJSON`

## Testing
- `npm test --silent` *(fails: vitest Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686cd74c10b4832b8aa839a78359a67f