### PR TITLE
Fix OpenRouter request handling

### DIFF
--- a/src/modules/PromptBuilder/index.tsx
+++ b/src/modules/PromptBuilder/index.tsx
@@ -111,7 +111,6 @@ function PromptBuilder() {
   // In handleRun and previewPayload, construct payload based on model type
   const buildPayload = (cfg: OpenRouterPromptConfig) => {
     if (isDeepResearchModel(cfg.model)) {
-      // For o3/o4 models, include tools/background if needed (not used here, but left for future)
       return {
         model: cfg.model,
         input: [
@@ -119,14 +118,11 @@ function PromptBuilder() {
           { role: 'user', content: cfg.userPrompt }
         ],
         max_tokens: cfg.maxTokens,
-        // tools: cfg.tools, // Uncomment if you ever add o3/o4 support again
-        // background: cfg.background, // Uncomment if you ever add o3/o4 support again
       };
     } else {
-      // For non-o3/o4 models, only include model, input, max_tokens
       return {
         model: cfg.model,
-        input: [
+        messages: [
           { role: 'system', content: cfg.systemPrompt || '' },
           { role: 'user', content: cfg.userPrompt }
         ],

--- a/src/services/ai-service.ts
+++ b/src/services/ai-service.ts
@@ -67,6 +67,25 @@ class AIService {
     throw new Error('OpenAI client not initialized');
   }
 
+  async runChatCompletion(payload: { model: string; messages: any[]; max_tokens?: number }): Promise<string> {
+    if (this.isOpenRouter && this.openRouterConfig) {
+      const res = await fetch(`${this.openRouterConfig.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.openRouterConfig.apiKey}`,
+          'Content-Type': 'application/json',
+          'HTTP-Referer': window.location.origin,
+          'X-Title': 'Research Agent',
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error('Failed to run completion');
+      const data = await safeParseJSON(res);
+      return data.choices?.[0]?.message?.content || '';
+    }
+    throw new Error('OpenAI client not initialized');
+  }
+
   async runDeepResearch(payload: { model: string; input: any[]; max_tokens?: number }): Promise<{
     responseId: string;
     stream: ReadableStream<string>;


### PR DESCRIPTION
## Summary
- support standard OpenRouter models by adding `runChatCompletion`
- switch non O3/O4 payloads to use `messages`
- update AgentRunner logic to call the new method

## Testing
- `npm test` *(fails: Playwright browser download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686d0f1ff3ac832b9f7ba3706516421b